### PR TITLE
Price Cannot Exceed $10,000

### DIFF
--- a/Bangazon/Models/Product.cs
+++ b/Bangazon/Models/Product.cs
@@ -25,6 +25,8 @@ namespace Bangazon.Models
         public string Title { get; set; }
 
         [Required]
+        [Range(0, 10000,
+            ErrorMessage = "Price cannot exceed $10,000.00")]
         [DisplayFormat(DataFormatString = "{0:C}")]
         public double Price { get; set; }
 


### PR DESCRIPTION
# Description

When a price is entered on a new product being created, if the price exceeds $10,000, an error message will populate and the item cannot be created.

Fixes Issue #13 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing Instructions

`git checkout master`
`git fetch --all`
`git checkout mm-PriceLimit`
`Run`
`Create new product`
`Attempt to make price over $10,000 and verify that the error message populates, and that the product cannot be created`

# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added test instructions that prove my fix is effective or that my feature works